### PR TITLE
Add TaskResult deserialization for abstract message types

### DIFF
--- a/debate-for-ai-alignment/requirements.txt
+++ b/debate-for-ai-alignment/requirements.txt
@@ -5,7 +5,7 @@ kedro-viz>=6.7.0,<11.0
 kedro[jupyter]~=0.19.10
 notebook
 scikit-learn~=1.5.1
-autogen-core
-autogen-ext[openai]
-autogen-agentchat
+autogen-core~=0.4.9
+autogen-ext[openai]~=0.4.9
+autogen-agentchat~=0.4.9
 gcsfs

--- a/debate-for-ai-alignment/src/debate_for_ai_alignment/pipelines/debate/models.py
+++ b/debate-for-ai-alignment/src/debate_for_ai_alignment/pipelines/debate/models.py
@@ -1,10 +1,20 @@
-from typing import Literal, List
+import inspect
+from typing import Any, Literal, List
 
+import autogen_agentchat.messages as agentchat_messages
 from autogen_agentchat.base import TaskResult
+from autogen_agentchat.messages import BaseMessage
 from autogen_core.models import TopLogprob
-from pydantic import BaseModel, root_validator, model_validator, Field
+from pydantic import BaseModel, root_validator, model_validator, field_validator, Field
 
 from debate_for_ai_alignment.pipelines.preprocessing.models import UniqueSet
+
+# Build a mapping of type name -> concrete message class for deserialization.
+_MESSAGE_TYPE_MAP = {
+    name: cls
+    for name, cls in inspect.getmembers(agentchat_messages, inspect.isclass)
+    if issubclass(cls, BaseMessage) and not inspect.isabstract(cls)
+}
 
 
 class DebateResult(BaseModel):
@@ -26,6 +36,27 @@ class MultipleRoundDebateResult(DebateResult):
     is_correct_option_first: bool
     n_rounds: int
     task_result: TaskResult
+
+    @field_validator("task_result", mode="before")
+    @classmethod
+    def deserialize_task_result(cls, v: Any) -> Any:
+        """Handle deserialization of TaskResult from dict.
+
+        Pydantic cannot deserialize the abstract BaseAgentEvent/BaseChatMessage
+        union directly. This validator maps each message dict to its concrete
+        type using the 'type' discriminator field before passing to TaskResult.
+        """
+        if isinstance(v, dict) and "messages" in v:
+            messages = []
+            for msg in v["messages"]:
+                if isinstance(msg, dict) and "type" in msg:
+                    msg_cls = _MESSAGE_TYPE_MAP.get(msg["type"])
+                    if msg_cls is not None:
+                        messages.append(msg_cls.model_validate(msg))
+                        continue
+                messages.append(msg)
+            v = {**v, "messages": messages}
+        return v
 
     @model_validator(mode="after")
     def check_lengths(self):


### PR DESCRIPTION
## Summary
This PR adds custom deserialization logic for `TaskResult` objects that contain abstract message types from the autogen library. The change enables proper handling of polymorphic message deserialization when reconstructing `MultipleRoundDebateResult` objects from dictionaries.

## Key Changes
- Added imports for `inspect`, `Any`, `autogen_agentchat.messages`, `BaseMessage`, and `field_validator`
- Created `_MESSAGE_TYPE_MAP`: a module-level mapping of message type names to their concrete class implementations, built by introspecting the autogen messages module
- Implemented `deserialize_task_result()` field validator on `MultipleRoundDebateResult` that:
  - Intercepts deserialization of the `task_result` field
  - Maps each message dictionary to its concrete type using the `type` discriminator field
  - Uses the type map to instantiate the correct message class before validation
  - Falls back to the original message if type mapping fails

## Implementation Details
The validator uses a "before" mode to preprocess the input dictionary before Pydantic's standard deserialization. This works around Pydantic's inability to deserialize abstract union types (like `BaseAgentEvent`/`BaseChatMessage`) by resolving each message to its concrete implementation class first. The type map is built once at module load time using `inspect.getmembers()` to find all non-abstract subclasses of `BaseMessage`.

https://claude.ai/code/session_016FqPoksaK5yY83xJF5htNX